### PR TITLE
workaround for autoUpdate SSL issue from switching to OS X 10.11 SDK

### DIFF
--- a/mac.js
+++ b/mac.js
@@ -58,6 +58,8 @@ module.exports = {
       if (buildVersion) {
         appPlist.CFBundleVersion = buildVersion
       }
+      
+      appPlist.NSAppTransportSecurity = { NSAllowsArbitraryLoads: true};
 
       if (opts.protocols) {
         helperPlist.CFBundleURLTypes = appPlist.CFBundleURLTypes = opts.protocols.map(function (protocol) {

--- a/mac.js
+++ b/mac.js
@@ -58,8 +58,8 @@ module.exports = {
       if (buildVersion) {
         appPlist.CFBundleVersion = buildVersion
       }
-      
-      appPlist.NSAppTransportSecurity = { NSAllowsArbitraryLoads: true};
+
+      appPlist.NSAppTransportSecurity = { NSAllowsArbitraryLoads: true }
 
       if (opts.protocols) {
         helperPlist.CFBundleURLTypes = appPlist.CFBundleURLTypes = opts.protocols.map(function (protocol) {


### PR DESCRIPTION
Fixes error `NSURLSession/NSURLConnection HTTP load failed (kCFStreamErrorDomainSSL, -9802)` that has been happening since `0.34.2` because the build switched to using OS X 10.11 SDK. 

Refs: https://github.com/atom/electron/issues/3442 and https://github.com/atom/electron/issues/3505
